### PR TITLE
Moved SendByteArrayToNode size check to constructor

### DIFF
--- a/buswear/src/main/java/pl/tajchert/buswear/wear/SendByteArrayToNode.java
+++ b/buswear/src/main/java/pl/tajchert/buswear/wear/SendByteArrayToNode.java
@@ -26,12 +26,13 @@ public class SendByteArrayToNode extends Thread {
         context = ctx;
         sticky = isSticky;
         clazzToSend = classToSend;
-    }
 
-    public void run() {
         if ((objectArray.length / 1024) > 100) {
             throw new RuntimeException("Object is too big to push it via Google Play Services");
         }
+    }
+
+    public void run() {
         GoogleApiClient googleApiClient = SendWearManager.getInstance(context);
         googleApiClient.blockingConnect(WearBusTools.CONNECTION_TIME_OUT_MS, TimeUnit.MILLISECONDS);
         NodeApi.GetConnectedNodesResult nodes = Wearable.NodeApi.getConnectedNodes(googleApiClient).await();

--- a/buswear/src/main/java/pl/tajchert/buswear/wear/WearBusTools.java
+++ b/buswear/src/main/java/pl/tajchert/buswear/wear/WearBusTools.java
@@ -99,4 +99,15 @@ public class WearBusTools {
         }
         return objArray;
     }
+
+    /**
+     * A convenience method that can be used to check if an event fits the size limit of
+     * what can be sent via Google Play Services.
+     * @param obj
+     * @return true if the object can be sent false if it cannot
+     */
+    public static boolean objectCanBeSent(Object obj) {
+        byte[] objArray = parseToSend(obj);
+        return objArray == null || (objArray.length / 1024) < 100;
+    }
 }


### PR DESCRIPTION
I moved the byte array size check to the constructor of SendByteArrayToNode allowing an app to fail gracefully if the limit is exceeded. Currently the check happens in the run method which has already been moved to another thread an thus cannot be caught by the existing "Object cannot be sent" log message.
