### PR TITLE
Updated findParcelMethod to handle private and protected constructors

### DIFF
--- a/buswear/src/main/java/pl/tajchert/buswear/EventBus.java
+++ b/buswear/src/main/java/pl/tajchert/buswear/EventBus.java
@@ -857,7 +857,7 @@ public class EventBus {
                     declaredConstructor.setAccessible(true);
                     return declaredConstructor.newInstance(WearBusTools.byteToParcel(objectArray));
                 } catch (Exception e) {
-                    Log.d(WearBusTools.BUSWEAR_TAG, "syncEvent error: " + e.getMessage());
+                    Log.d(TAG, "syncEvent error: " + e.getMessage());
                 }
             }
         }

--- a/buswear/src/main/java/pl/tajchert/buswear/EventBus.java
+++ b/buswear/src/main/java/pl/tajchert/buswear/EventBus.java
@@ -853,13 +853,11 @@ public class EventBus {
         for (Class classTmp : classList) {
             if (className.equals(classTmp.getSimpleName())) {
                 try {
-                    try {
-                        return classTmp.getConstructor(Parcel.class).newInstance(WearBusTools.byteToParcel(objectArray));
-                    } catch (Exception e) {
-                        Log.d(WearBusTools.BUSWEAR_TAG, "syncEvent error: " + e.getMessage());
-                    }
+                    Constructor declaredConstructor = classTmp.getDeclaredConstructor(Parcel.class);
+                    declaredConstructor.setAccessible(true);
+                    return declaredConstructor.newInstance(WearBusTools.byteToParcel(objectArray));
                 } catch (Exception e) {
-                    Log.d(TAG, "syncEvent error: " + e.getMessage());
+                    Log.d(WearBusTools.BUSWEAR_TAG, "syncEvent error: " + e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
This change allows for reflection to locate private and protected `Parcel` constructors which should resolve #5.

This also removed the wrapping try catch as I'm guessing that was accidentally included.
